### PR TITLE
Fix publish failure

### DIFF
--- a/lottie-compose/build.gradle
+++ b/lottie-compose/build.gradle
@@ -1,6 +1,24 @@
 import com.vanniktech.maven.publish.SonatypeHost
 import static de.fayard.refreshVersions.core.Versions.versionFor
 
+buildscript{
+  ext {
+    val_build_plugin_version = "3.2.1"
+  }
+  repositories {
+    maven {
+      url "https://reposilite.svc.ifit.com/reposilite"
+      credentials {
+        username valinor_maven_username
+        password valinor_maven_password
+      }
+    }
+  }
+  dependencies {
+    classpath "com.ifit:valinor-build-plugin:$val_build_plugin_version"
+  }
+}
+
 plugins {
   id 'com.android.library'
   id 'org.jetbrains.kotlin.android'
@@ -42,15 +60,6 @@ publishing {
       artifactId 'lottie-compose'
       version '6.4.1-SNAPSHOT'
       artifact("$buildDir/outputs/aar/lottie-compose-release.aar")
-    }
-  }
-  repositories {
-    maven {
-      url "https://reposilite.svc.ifit.com/reposilite"
-      credentials {
-        username valinor_maven_username
-        password valinor_maven_password
-      }
     }
   }
 }


### PR DESCRIPTION
Error was

```
    Reason: Task ':lottie-compose:publishValinorPublicationToMavenRepository' uses this output of task ':lottie-compose:bundleReleaseAar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':lottie-compose:bundleReleaseAar' as an input of ':lottie-compose:publishValinorPublicationToMavenRepository'.
      2. Declare an explicit dependency on ':lottie-compose:bundleReleaseAar' from ':lottie-compose:publishValinorPublicationToMavenRepository' using Task#dependsOn.
      3. Declare an explicit dependency on ':lottie-compose:bundleReleaseAar' from ':lottie-compose:publishValinorPublicationToMavenRepository' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.6/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```